### PR TITLE
fix: css var in highlight pseudos

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Word Hunter",
   "description": "Discover new words you don't know on any web page",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "manifest_version": 3,
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA37Tu6LgsThnqIusXCvgDP+kzjHmJgwehDp01nEvTCH3N19Qpe3+q6o20yjMfyT1681f3mzugV4scpjSsYH7ixO8wZHDNBwJlPPLV8jjpwRd/rBiXLYw7sSSHsX1dN7mQuKdua7WrsN+CUc7s8acq0F9lAXGtsk/BA3tNSidB5kVmog1iLf3m6wbbYK9wKmlgIjw8OkAxOs4YnZ/Z5Dfj4lPZ0aYxUmQkXSZgc3Jj0IUiQBfY3+RsJw0u7M2njPlU6AQ8pPET3BHY86ee0xSksINMrVYYMjAmHv+05RzIF+rANlHGqHYoPaD3z/rxkeki4uXXkVEi4Yv+AhdKxGUwYwIDAQAB",
   "icons": {

--- a/src/lib/markStyle.ts
+++ b/src/lib/markStyle.ts
@@ -11,19 +11,15 @@ export function genMarkStyle() {
   const bgColor1 = settings()['colors'][1]
 
   const cssVars = `
-    ${unknownSelector} {
+    :root {
         --wh-text-color-0: ${textColor0};
         --wh-bg-color-0: ${bgColor0};
-    }
-    ${contextSelector} {
         --wh-text-color-1: ${textColor1};
         --wh-bg-color-1: ${bgColor1};
     }
     @media (prefers-color-scheme: dark) {
-        ${unknownSelector} {
+        :root {
             --wh-bg-color-0: ${generateDarkModeColor(bgColor0)};
-        }
-        ${contextSelector} {
             --wh-bg-color-1: ${generateDarkModeColor(bgColor1)};
         }
     }


### PR DESCRIPTION
fix: CSS custom properties defined in `::highlight` not worked since Chrome 126
- https://issues.chromium.org/issues/347060521
- https://blogs.igalia.com/schenney/css-custom-properties-in-highlight-pseudos/