### PR TITLE
fix: alter manifest's use_dynamic_url field value

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Word Hunter",
   "description": "Discover new words you don't know on any web page",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "manifest_version": 3,
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA37Tu6LgsThnqIusXCvgDP+kzjHmJgwehDp01nEvTCH3N19Qpe3+q6o20yjMfyT1681f3mzugV4scpjSsYH7ixO8wZHDNBwJlPPLV8jjpwRd/rBiXLYw7sSSHsX1dN7mQuKdua7WrsN+CUc7s8acq0F9lAXGtsk/BA3tNSidB5kVmog1iLf3m6wbbYK9wKmlgIjw8OkAxOs4YnZ/Z5Dfj4lPZ0aYxUmQkXSZgc3Jj0IUiQBfY3+RsJw0u7M2njPlU6AQ8pPET3BHY86ee0xSksINMrVYYMjAmHv+05RzIF+rANlHGqHYoPaD3z/rxkeki4uXXkVEi4Yv+AhdKxGUwYwIDAQAB",
   "icons": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,34 @@
+import fs from 'node:fs'
+import path from 'node:path'
 import { defineConfig } from 'vite'
 import solidPlugin from 'vite-plugin-solid'
 import { crx, ManifestV3Export } from '@crxjs/vite-plugin'
 import manifest from './manifest.json'
+
+/**
+ * @HACK: Chrome 128 implements the use_dynamic_url feature. If it's set to true, chrome will not load
+ * the content js file, and crx always set this field to true.
+ */
+function updateManifest() {
+  const manifestPath = path.relative(__dirname, './build/manifest.json')
+  const json = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+
+  if (json) {
+    json.web_accessible_resources.forEach((resource: any) => {
+      resource.use_dynamic_url = false
+    })
+
+    fs.writeFileSync(manifestPath, JSON.stringify(json, null, 2))
+  }
+}
+
+function updateManifestPlugin() {
+  return {
+    name: 'update-manifest',
+    transform: updateManifest,
+    writeBundle: updateManifest
+  }
+}
 
 export default defineConfig({
   build: {
@@ -14,5 +41,5 @@ export default defineConfig({
     },
     sourcemap: false
   },
-  plugins: [solidPlugin(), crx({ manifest: manifest as ManifestV3Export })]
+  plugins: [solidPlugin(), crx({ manifest: manifest as ManifestV3Export }), updateManifestPlugin()]
 })


### PR DESCRIPTION
According to [this Chromium review](https://chromium-review.googlesource.com/c/chromium/src/+/5636785), Chrome Canary has implemented the use_dynamic_url feature in the manifest, which will prevent page load content scripts. Therefore, we have set this field to false. However, the CRX plugin does not support this configuration yet, so we have to use this temporary workaround to avoid the bug.