### PR TITLE
Fix/disable on domain

### DIFF
--- a/src/content/card.tsx
+++ b/src/content/card.tsx
@@ -25,7 +25,14 @@ import {
 import { getMessagePort } from '../lib/port'
 import { Dict } from './dict'
 import { adapters, AdapterKey } from './adapters'
-import { getWordContext, safeEmphasizeWordInText, getFaviconByDomain, settings, explode } from '../lib'
+import {
+  getWordContext,
+  safeEmphasizeWordInText,
+  getFaviconByDomain,
+  settings,
+  explode,
+  isMatchURLPattern
+} from '../lib'
 import { readBlacklist } from '../lib/blacklist'
 
 let timerShowRef: number
@@ -51,7 +58,8 @@ export const WhCard = customElement('wh-card', () => {
   onMount(() => {
     readBlacklist().then(async blacklist => {
       try {
-        if (blacklist.includes(location.host) || blacklist.includes(top?.location.host)) return
+        if (isMatchURLPattern(blacklist, location.host)[0] || isMatchURLPattern(blacklist, top?.location.host)[0])
+          return
       } catch (e) {
         // do nothing, some times the frame is cross origin, and will throw error for `top.location.host`
       }

--- a/src/lib/blacklist.ts
+++ b/src/lib/blacklist.ts
@@ -1,6 +1,7 @@
 import { Messages, StorageKey } from '../constant'
 import { getSyncValue, getLocalValue } from './storage'
 import { DEFAULT_SETTINGS } from './settings'
+import { isMatchURLPattern } from './utils'
 
 export const readBlacklist = async () => {
   const settings = (await getSyncValue(StorageKey.settings)) ?? DEFAULT_SETTINGS
@@ -11,7 +12,7 @@ export const readBlacklist = async () => {
 const updateAppIcon = async () => {
   if (document.visibilityState !== 'hidden' && !chrome.tabs && window.top === window.self) {
     const blacklist = await readBlacklist()
-    const shouldAvailable = !blacklist.includes(top?.location.host)
+    const shouldAvailable = !isMatchURLPattern(blacklist, top?.location.host)[0]
     const isAppAvailable = (await getLocalValue(Messages.app_available as unknown as StorageKey)) ?? true
     if (isAppAvailable !== shouldAvailable) {
       chrome.runtime.sendMessage({ [Messages.app_available]: shouldAvailable })

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -156,3 +156,29 @@ export function getRelativeTimeString(date1: number, date2: number, locale = 'en
     return rtf.format(-seconds, 'second')
   }
 }
+
+export function isMatchURLPattern(list: string[], checkURL?: string) {
+  checkURL = checkURL?.trim()
+
+  if (!checkURL) {
+    return [false, ''] as const
+  }
+
+  let matchedItem = ''
+
+  const isMatch = list.some(item => {
+    const isMatch = new URLPattern({
+      hostname: `{*.}?${item}`
+    }).test({
+      hostname: checkURL
+    })
+
+    if (isMatch) {
+      matchedItem = item
+    }
+
+    return isMatch
+  })
+
+  return [isMatch, matchedItem] as const
+}

--- a/src/popup/app.tsx
+++ b/src/popup/app.tsx
@@ -53,11 +53,21 @@ export const App = () => {
     })
   }
 
+  function isInBlackList(blackList: string[], url: string) {
+    return blackList.some(item =>
+      new URLPattern({
+        hostname: `{*.}?${item}`
+      }).test({
+        hostname: url
+      })
+    )
+  }
+
   const getBannedState = async () => {
     const tabs = await chrome.tabs.query({ active: true, currentWindow: true })
     const host = new URL(tabs[0].url!).host
     const blacklist = settings()['blacklist']
-    const inBlocklist = blacklist.includes(host)
+    const inBlocklist = isInBlackList(blacklist, host)
     return [inBlocklist, host, blacklist] as const
   }
 


### PR DESCRIPTION
This PR partially fixes https://github.com/word-hunter/word-hunter/issues/81.

Before this PR, the blacklist used the current tab's domain for an exact match. For example, "www.siteA.com" or "siteA.com" would not match "video.siteA.com".

This PR ensures that "siteA.com" will match "video.siteA.com". However, it still fails to match "www.siteA.com".