### PR TITLE
Feat/only display chinese translation once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ build.pem
 
 # secrets
 secrets.*.js
+
+# IDEA IDE
+.idea


### PR DESCRIPTION
Fix [Issue 77](https://github.com/word-hunter/word-hunter/issues/77).

There is a scenario that makes this behavior less intuitive: the browser can remember the last position and restore it. Currently, the Chinese translation will only appear in this viewport, which is not necessarily at the top of the page. Therefore, when you scroll up, the translation of the same unknown word will not appear because we consider "first" to mean when we first saw it, not the first appearance from the top of the page.