### PR TITLE
Optimize preload stratagem

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -94,15 +94,11 @@ const setupOffscreenDocument = async (path: string) => {
 }
 
 const checkOffscreenDocumentExist = async (offscreenUrl: string) => {
-  // @ts-ignore
   if (chrome.runtime.getContexts) {
-    // @ts-ignore
     const existingContexts = await chrome.runtime.getContexts({
-      // @ts-ignore
-      contextTypes: ['OFFSCREEN_DOCUMENT'],
+      contextTypes: [chrome.runtime.ContextType.OFFSCREEN_DOCUMENT],
       documentUrls: [offscreenUrl]
     })
-    // @ts-ignore
     return existingContexts.length > 0
     // @ts-ignore
   } else if (globalThis.clients) {

--- a/src/content/adapters/collins/index.ts
+++ b/src/content/adapters/collins/index.ts
@@ -15,22 +15,17 @@ export class CollinsDict implements Adapter {
     return dictStyles
   }
 
-  async lookup({ word }: { word: string; text?: string }) {
+  async lookup({ word, isPreload }: { word: string; text?: string; isPreload: boolean }) {
     if (cache.get(word)) return Promise.resolve(cache.get(word)!)
-    try {
-      const doc = await this.fetchDocument(word)
-      const data = this.parseDocument(doc, word)
-      cache.set(word, data)
-      return data
-    } catch (e) {
-      console.warn(e)
-      return ''
-    }
+    const doc = await this.fetchDocument(word, isPreload)
+    const data = this.parseDocument(doc, word)
+    cache.set(word, data)
+    return data
   }
 
-  private async fetchDocument(word: string) {
+  private async fetchDocument(word: string, isPreload: boolean) {
     const url = this.getPageUrl(word)
-    const html = await fetchText(url)
+    const html = await fetchText(url, isPreload)
     const doc = new DOMParser().parseFromString(html, 'text/html')
     return doc
   }

--- a/src/content/adapters/fetch.ts
+++ b/src/content/adapters/fetch.ts
@@ -1,7 +1,14 @@
 import { Messages } from '../../constant'
 import { sendMessage } from '../../lib/port'
 
-export async function fetchText(url: string): Promise<string> {
-  const result = await sendMessage(Messages.fetch_html, { url })
-  return result ?? ''
+export async function fetchText(url: string, isPreload?: boolean): Promise<string> {
+  const result: string | { isError: boolean; message: string } = await sendMessage(Messages.fetch_html, {
+    url,
+    isPreload
+  })
+  if (typeof result === 'string') {
+    return result
+  } else {
+    throw new Error(result.message)
+  }
 }

--- a/src/content/adapters/google/index.ts
+++ b/src/content/adapters/google/index.ts
@@ -17,27 +17,22 @@ export class GoogleDict implements Adapter {
     return dictStyles
   }
 
-  async lookup({ word }: { word: string; text?: string }) {
+  async lookup({ word, isPreload }: { word: string; text?: string; isPreload?: boolean }) {
     if (cache.get(word)) return Promise.resolve(cache.get(word)!)
-    try {
-      const html = await this.fetch(word)
-      const doc = new DOMParser().parseFromString(html, 'text/html')
+    const html = await this.fetch(word, isPreload)
+    const doc = new DOMParser().parseFromString(html, 'text/html')
 
-      const data = this.parseDocument(doc, html, word)
-      cache.set(word, data)
-      return data
-    } catch (e) {
-      console.warn(e)
-      return ''
-    }
+    const data = this.parseDocument(doc, html, word)
+    cache.set(word, data)
+    return data
   }
 
-  private async fetch(word: string) {
+  private async fetch(word: string, isPreload?: boolean) {
     const url = this.getPageUrl(word)
     try {
-      return await fetchText(url)
+      return await fetchText(url, isPreload)
     } catch (e) {
-      return await fetchText(url.replace('q=meaning', 'q=define'))
+      return await fetchText(url.replace('q=meaning', 'q=define'), isPreload)
     }
   }
 

--- a/src/content/adapters/haici/index.ts
+++ b/src/content/adapters/haici/index.ts
@@ -15,22 +15,17 @@ export class HaiCiDict implements Adapter {
     return dictStyles
   }
 
-  async lookup({ word }: { word: string; text?: string }) {
+  async lookup({ word, isPreload }: { word: string; text?: string; isPreload?: boolean }) {
     if (cache.get(word)) return Promise.resolve(cache.get(word)!)
-    try {
-      const doc = await this.fetchDocument(word)
-      const data = this.parseDocument(doc, word)
-      cache.set(word, data)
-      return data
-    } catch (e) {
-      console.warn(e)
-      return ''
-    }
+    const doc = await this.fetchDocument(word, isPreload)
+    const data = this.parseDocument(doc, word)
+    cache.set(word, data)
+    return data
   }
 
-  private async fetchDocument(word: string) {
+  private async fetchDocument(word: string, isPreload?: boolean) {
     const url = this.getPageUrl(word)
-    const html = await fetchText(url)
+    const html = await fetchText(url, isPreload)
     const doc = new DOMParser().parseFromString(html, 'text/html')
     return doc
   }

--- a/src/content/adapters/longman/index.ts
+++ b/src/content/adapters/longman/index.ts
@@ -15,22 +15,17 @@ export class LongManDict implements Adapter {
     return dictStyles
   }
 
-  async lookup({ word }: { word: string; text?: string }) {
+  async lookup({ word, isPreload }: { word: string; text?: string; isPreload?: boolean }) {
     if (cache.get(word)) return Promise.resolve(cache.get(word)!)
-    try {
-      const doc = await this.fetchDocument(word)
-      const data = this.parseDocument(doc, word)
-      cache.set(word, data)
-      return data
-    } catch (e) {
-      console.warn(e)
-      return ''
-    }
+    const doc = await this.fetchDocument(word, isPreload)
+    const data = this.parseDocument(doc, word)
+    cache.set(word, data)
+    return data
   }
 
-  private async fetchDocument(word: string) {
+  private async fetchDocument(word: string, isPreload?: boolean) {
     const url = this.getPageUrl(word)
-    const html = await fetchText(url)
+    const html = await fetchText(url, isPreload)
     const doc = new DOMParser().parseFromString(html, 'text/html')
     return doc
   }

--- a/src/content/adapters/openai/index.ts
+++ b/src/content/adapters/openai/index.ts
@@ -18,17 +18,12 @@ export class OpenAiDict implements Adapter {
     return dictStyles
   }
 
-  async lookup({ word, text }: { word: string; text?: string }) {
+  async lookup({ word, text }: { word: string; text?: string; isPreload?: boolean }) {
     if (cache.get(word)) return Promise.resolve(cache.get(word)!)
-    try {
-      const html = await fetchExplain(word, text)
-      const data = html
-      cache.set(word, data)
-      return data
-    } catch (e) {
-      console.warn(e)
-      return ''
-    }
+    const html = await fetchExplain(word, text)
+    const data = html
+    cache.set(word, data)
+    return data
   }
 
   getPageUrl(word: string) {

--- a/src/content/adapters/type.ts
+++ b/src/content/adapters/type.ts
@@ -5,7 +5,7 @@ export interface Adapter {
   readonly sectionSelector: string
 
   get style(): string
-  lookup(context: { word: string; text?: string }): Promise<string>
+  lookup(context: { word: string; text?: string; isPreload?: boolean }): Promise<string>
   getPageUrl: (word: string) => string
   getWordByHref(href: string): string
   cspViolationHandler?: (e: SecurityPolicyViolationEvent, root: HTMLElement) => void

--- a/src/content/card.tsx
+++ b/src/content/card.tsx
@@ -20,9 +20,9 @@ import {
   zenExcludeWords,
   setZenExcludeWords,
   getWordAllTenses,
-  skimmedWords,
   getRangeAtPoint
 } from './highlight'
+import { preload } from '../lib/preload'
 import { getMessagePort } from '../lib/port'
 import { Dict } from './dict'
 import { adapters, AdapterKey } from './adapters'
@@ -32,7 +32,6 @@ import {
   getFaviconByDomain,
   settings,
   explode,
-  debounce,
   isMatchURLPattern
 } from '../lib'
 import { readBlacklist } from '../lib/blacklist'
@@ -70,29 +69,9 @@ export const WhCard = customElement('wh-card', () => {
     })
   })
 
-  const [preloadedWords, setPreloadWords] = createSignal<Set<string>>(new Set())
-  function addPreLoadedWords(words: string[]) {
-    words.forEach(word => {
-      preloadedWords().add(word)
-    })
-    setPreloadWords(new Set([...preloadedWords()]))
-  }
-
-  const nextPreloadWords = () => {
-    return [...skimmedWords()].filter(word => !preloadedWords().has(word)).slice(0, 4)
-  }
-
-  const preloadDebounce = debounce(async (words: string[]) => {
-    await Promise.all(words.map(word => getDictAdapter().lookup({ word })))
-    addPreLoadedWords(words)
-  }, 500)
-
   createEffect(() => {
     if (settings().preload) {
-      const words = nextPreloadWords()
-      if (words.length > 0) {
-        preloadDebounce(words)
-      }
+      preload(getDictAdapter())
     }
   })
 

--- a/src/content/dict.tsx
+++ b/src/content/dict.tsx
@@ -45,7 +45,7 @@ export function Dict(props: Props) {
         <Match when={!def.loading && (def.error || !def())}>
           <div class="no_result">
             <img src={chrome.runtime.getURL('icons/robot.png')} alt="no definition" />
-            not found definition
+            {def.error ?? 'No definition found.'}
           </div>
         </Match>
         <Match when={!def.loading && def()}>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -8,6 +8,15 @@ declare interface Window extends WindowOrWorkerGlobalScope {
   __getPageStatistics: () => readonly [number, number, number]
 }
 
+interface HTMLElement {
+  _intersected?: boolean // Used by the IntersectionObserver
+}
+
+interface Set<T> {
+  difference(otherSet: Set<T>): Set<T>
+  union(otherSet: Set<T>): Set<T>
+}
+
 // Types for the AIModelAvailability enum
 type AIModelAvailability = 'readily' | 'after-download' | 'no'
 

--- a/src/lib/preload.ts
+++ b/src/lib/preload.ts
@@ -1,0 +1,56 @@
+import { createSignal } from 'solid-js'
+import { debounce } from './utils'
+import { Adapter } from '../content/adapters'
+
+const MAX_PRELOAD_COUNT = 200
+const [preloadQueue, _setPreloadQueue] = createSignal<Set<string>>(new Set())
+const [preloading, setPreloading] = createSignal(false)
+const [preloadedWords, setPreloadWords] = createSignal<Set<string>>(new Set())
+
+const setPreloadQueue = (words: Set<string> = new Set()) => {
+  if (preloadedWords().size < MAX_PRELOAD_COUNT) {
+    _setPreloadQueue(words)
+  }
+}
+
+const nextPreloadWords = () => {
+  return [...preloadQueue()].filter(word => !preloadedWords().has(word)).slice(0, 4)
+}
+
+const wordRetryCounts = new Map<string, number>()
+
+const preloadDebounce = debounce((words: string[], dictAdapter: Adapter) => {
+  requestIdleCallback(async () => {
+    if (dictAdapter.name === 'openai') return
+    setPreloading(true)
+    const loadedWrods: string[] = []
+    await Promise.allSettled(
+      words.map(word =>
+        dictAdapter
+          .lookup({ word, isPreload: true })
+          .then(() => {
+            loadedWrods.push(word)
+          })
+          .catch(e => {
+            // if retry 3 times, then skip this word next time
+            wordRetryCounts.set(word, (wordRetryCounts.get(word) || 0) + 1)
+            if ((wordRetryCounts.get(word) || 0) >= 3) {
+              loadedWrods.push(word)
+            }
+          })
+      )
+    )
+    setPreloading(false)
+    setPreloadWords(new Set([...preloadedWords(), ...loadedWrods]))
+  })
+}, 500)
+
+const preload = (dictAdapter: Adapter) => {
+  if (preloading() || preloadedWords().size > MAX_PRELOAD_COUNT) return
+  const words = nextPreloadWords()
+  if (words.length > 0) {
+    preloadDebounce(words, dictAdapter)
+  }
+}
+
+export { preload, preloadQueue, setPreloadQueue }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -78,10 +78,7 @@ export function executeScript<T>(func: () => T): Promise<{ result: T }[]> {
 }
 
 export function uuidv4() {
-  // @ts-ignore
-  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, c =>
-    (c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16)
-  )
+  return crypto.randomUUID()
 }
 
 export function debounce<T extends (...args: any[]) => void>(func: T, delay: number): (...args: Parameters<T>) => void {

--- a/src/review/app.tsx
+++ b/src/review/app.tsx
@@ -89,11 +89,10 @@ export const App = () => {
   }
 
   const setFullScrren = () => {
-    var iframe = document.getElementById('youtube-player')
+    var iframe = document.getElementById('youtube-player') as HTMLIFrameElement
     if (iframe?.requestFullscreen) {
       iframe.requestFullscreen()
-      // @ts-ignore
-      iframe.contentWindow.postMessage('{"event":"command","func":"playVideo","args":""}', '*')
+      iframe.contentWindow?.postMessage('{"event":"command","func":"playVideo","args":""}', '*')
     }
   }
 


### PR DESCRIPTION
- Remove words from the preload queue when they are out of view.
- Set the preload fetch `timeout` to 5000ms.
- Set the preload fetch `priority` to low.
- Limit the maximum preload count to 200.
- Wrap the preload fetch with `requestIdleCallback` to ensure it runs when the browser is idle.
- Disable preload for the OpenAI tab.