### PR TITLE
allow pasted gdrive token used in desktop

### DIFF
--- a/src/lib/backup/drive.ts
+++ b/src/lib/backup/drive.ts
@@ -5,7 +5,10 @@ const UPLOAD_API_PATH = 'https://www.googleapis.com/upload/drive/v3/files'
 export const FOLDER_NAME = 'Word Hunter Backup'
 export const FILE_NAME = 'word_hunter_backup.json'
 
-export const isMobile = navigator.userAgent.includes('Mobile') || navigator.userAgent.includes('Android')
+export const isMobile =
+  navigator.userAgent.includes('Mobile') ||
+  navigator.userAgent.includes('Android') ||
+  new URLSearchParams(location.search).get('mobile') === '1'
 
 export function isValidAuthToken(token: string) {
   return !!token && /ya29.[0-9A-Za-z-_]+/.test(token)
@@ -65,8 +68,6 @@ export async function downloadFile(fileId: string) {
   const file = await makeRequest('GET', `${API_PATH}/${fileId}?alt=media`, 'json')
   return file
 }
-
-export async function mergeAndSync() {}
 
 async function makeRequest(
   method: 'GET' | 'POST' | 'PUT' | 'PATCH',


### PR DESCRIPTION
The `mobile_auth_token` is originally for the Mask browser on Android, which support Chrome extension but not support `chrome.identity.getAuthToken`.
> 1. set up the Google Drive sync on the Desktop Chrome in the settings page.
> 2. open: chrome://identity-internals/ in Chrome, and copy the Access Token value
> 3. open the settings page on the mobile side, and paste the Access Token into textarea, then it should work.

Now, we change `isMobile` to support search params, So even in PC browser, if the browser not support `chrome.identity.getAuthToken` (like Microsoft Edge), the users can use Google Drive sync via paste Google auth token into the textarea in 
> chrome-extension://nigkedajkofkhoedhgiipmigiebldaem/src/options.html?mobile=1

