### PR TITLE
fix(vite): disable cors

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,5 +41,8 @@ export default defineConfig({
     },
     sourcemap: false
   },
+  server: {
+    cors: false
+  },
   plugins: [solidPlugin(), crx({ manifest: manifest as ManifestV3Export }), updateManifestPlugin()]
 })


### PR DESCRIPTION
When enable `tailwind` in dev, the page will display something like
```text
Refused to load the script 'chrome-extension://6d0e19f6-06ad-4b3f-9edf-893372f9355b/vendor/vite-client.js' 
because it violates the following Content Security Policy directive: "script-src 'self' 
'wasm-unsafe-eval' 'inline-speculation-rules' http://localhost:* http://127.0.0.1:*". 
Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback.
```

I also found a similar issue in `crxjs`, but it seems they don't have a proper fix yet: https://github.com/crxjs/chrome-extension-tools/issues/505.

Right now, disable cors can fix this.