### PR TITLE
Reuse old method get context

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Word Hunter",
   "description": "Discover new words you don't know on any web page",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "manifest_version": 3,
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA37Tu6LgsThnqIusXCvgDP+kzjHmJgwehDp01nEvTCH3N19Qpe3+q6o20yjMfyT1681f3mzugV4scpjSsYH7ixO8wZHDNBwJlPPLV8jjpwRd/rBiXLYw7sSSHsX1dN7mQuKdua7WrsN+CUc7s8acq0F9lAXGtsk/BA3tNSidB5kVmog1iLf3m6wbbYK9wKmlgIjw8OkAxOs4YnZ/Z5Dfj4lPZ0aYxUmQkXSZgc3Jj0IUiQBfY3+RsJw0u7M2njPlU6AQ8pPET3BHY86ee0xSksINMrVYYMjAmHv+05RzIF+rANlHGqHYoPaD3z/rxkeki4uXXkVEi4Yv+AhdKxGUwYwIDAQAB",
   "icons": {

--- a/src/content/card.css
+++ b/src/content/card.css
@@ -1,7 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 .word_card {
   --bg-color: #fff;
   --border-color: rgba(0, 0, 0, 0.3);
@@ -169,6 +165,7 @@
         white-space: normal;
         word-break: break-word;
         word-wrap: break-word;
+        text-justify: balance;
       }
 
       b {
@@ -196,6 +193,15 @@
             opacity: 0.8;
           }
         }
+      }
+
+      .buttons {
+        position: absolute;
+        top: 4px;
+        right: 0;
+        display: flex;
+        gap: 4px;
+        align-items: center;
       }
 
       button {

--- a/src/content/card.tsx
+++ b/src/content/card.tsx
@@ -390,7 +390,7 @@ function ContextList(props: { contexts: WordContext[] }) {
   const allTensionWords = () => getWordAllTenses(curWord()).reverse()
   const [editingContext, setEditingContext] = createSignal<WordContext | null>(null)
   const [prevText, setPrevText] = createSignal<string>('')
-  let editRef: HTMLDivElement | undefined
+  let editRef: HTMLPreElement | undefined
 
   function enterEditMode(context: WordContext) {
     setIsEditingContext(true)
@@ -427,12 +427,13 @@ function ContextList(props: { contexts: WordContext[] }) {
     exitEditMode()
   }
 
-  function updateAndFocusEl(el: HTMLDivElement) {
-    editRef = el
-    setTimeout(() => {
-      editRef?.focus()
-    })
-  }
+  createEffect(() => {
+    if (isEditingContext()) {
+      setTimeout(() => {
+        editRef?.focus()
+      })
+    }
+  })
 
   return (
     <Show
@@ -454,17 +455,12 @@ function ContextList(props: { contexts: WordContext[] }) {
             return (
               <div>
                 <Show when={editingContext() === context}>
-                  <div
-                    ref={el => updateAndFocusEl(el)}
-                    onblur={() => saveContext()}
-                    oninput={() => updateContextText()}
-                    contenteditable
-                  >
+                  <pre ref={editRef} onblur={() => saveContext()} oninput={() => updateContextText()} contenteditable>
                     {context.text}
-                  </div>
+                  </pre>
                 </Show>
                 <Show when={editingContext() !== context}>
-                  <pre innerHTML={highlightedContext}></pre>
+                  <pre innerHTML={highlightedContext} ondblclick={() => enterEditMode(context)}></pre>
                 </Show>
                 <p>
                   <img src={context.favicon || getFaviconByDomain(context.url)} alt="favicon" />
@@ -472,7 +468,7 @@ function ContextList(props: { contexts: WordContext[] }) {
                     {context.title}
                   </a>
                 </p>
-                <div class="flex items-center absolute top-1 right-0 gap-1">
+                <div class="buttons">
                   <button title="edit context" onClick={() => enterEditMode(context)}>
                     <img src={chrome.runtime.getURL('icons/edit.png')} alt="edit" />
                   </button>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -19,76 +19,38 @@ export const getDocumentTitle = () => {
   return document.title.substring(0, 40)
 }
 
-const MAX_CONTEXT_WORDS_LENGTH = 100
-function getTextAroundPoint(x: number, y: number) {
-  const yStart = y - 30
-  const yEnd = y + 30
-  let rangeStart
-  let rangeEnd
-  let textNodeStart
-  let textNodeEnd
-
-  // @ts-ignore
-  if (document.caretPositionFromPoint) {
-    // @ts-ignore
-    rangeStart = document.caretPositionFromPoint(x, yStart)
-    textNodeStart = rangeStart.offsetNode
-    // @ts-ignore
-    rangeEnd = document.caretPositionFromPoint(x, yEnd)
-    textNodeEnd = rangeEnd.offsetNode
-  } else if (document.caretRangeFromPoint) {
-    rangeStart = document.caretRangeFromPoint(x, yStart)
-    rangeEnd = document.caretRangeFromPoint(x, yEnd)
-    textNodeStart = rangeStart!.startContainer
-    textNodeEnd = rangeEnd!.startContainer
-  }
-
-  const textRange = document.createRange()
-  textRange.setStart(textNodeStart, 0)
-  textRange.setEnd(textNodeEnd, textNodeEnd.textContent.length - 1)
-
-  return textRange.toString().trim()
+function isPDFjsReaderSpan(node: HTMLElement) {
+  return (
+    location.host === 'mozilla.github.io' &&
+    (node.getAttribute('role') === 'presentation' || node.classList.contains('markedContent'))
+  )
 }
 
 const wordContextCache = new WeakMap<Range, string>()
-export function getWordContext(range: Range) {
+export const getWordContext = (range: Range, originWord?: string): string => {
   if (wordContextCache.has(range)) {
     return wordContextCache.get(range) ?? ''
   }
-
-  const word = range.toString().trim()
-  const rect = range.getBoundingClientRect()
-  let text = getTextAroundPoint(rect.x, rect.y)
-
-  if (text.split(' ').length > MAX_CONTEXT_WORDS_LENGTH) {
-    // split sentence
-    const sentences = text.split(/[.?;]/g)
-    let wordIndexStart = text.indexOf(word)
-    let wordIndexEnd = wordIndexStart + word.length
-
-    // has multiple sentences
-    if (sentences.length > 1) {
-      let sentenceStart = 0
-      sentences.some(s => {
-        const sentenceEnd = sentenceStart + s.length
-
-        if (wordIndexStart >= sentenceStart) {
-          wordIndexStart = sentenceStart
-
-          if (wordIndexEnd <= sentenceEnd) {
-            text = text.substring(sentenceStart, sentenceEnd + 1).trim()
-            return true
-          } else {
-            wordIndexStart = sentenceEnd + 1
-          }
-        }
-        sentenceStart = sentenceEnd + 1
-      })
-    }
+  let pNode = range.commonAncestorContainer?.parentElement as HTMLElement
+  while (getComputedStyle(pNode).display.startsWith('inline') || isPDFjsReaderSpan(pNode)) {
+    pNode = pNode.parentElement as HTMLElement
   }
+  // remove all <w-mark-t> tags in context
+  const pNodeClone = pNode.cloneNode(true) as HTMLElement
+  pNodeClone.querySelectorAll('w-mark-t').forEach(t => t.remove())
 
-  wordContextCache.set(range, text)
-  return text
+  const text = pNodeClone?.textContent ?? originWord ?? ''
+  const sliceStart = text.indexOf(range.commonAncestorContainer?.textContent ?? originWord ?? '') ?? 0
+  let start = sliceStart + range.startOffset
+  let end = sliceStart + range.endOffset
+  while (start > 0 && text.at(start - 1) !== '.') start--
+  while (end < text.length && text.at(end) !== '.') end++
+  if (text.at(end) === '.') end++
+
+  pNodeClone.remove()
+  const result = text.slice(start, end)
+  wordContextCache.set(range, result)
+  return result
 }
 
 export const downloadAsJsonFile = (content: string, filename: string) => {


### PR DESCRIPTION
- Reuse old `getWordContext` for a stable result
- not use tailwind in context at present, will migrate all at once later